### PR TITLE
Fixup PyPI long description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     version='0.3.0',
     description='Splunk search client',
     long_description=long_description,
+    long_description_content_type="text/markdown",
     author='Ryan Currah',
     author_email='ryan@currah.ca',
     url='https://github.com/ryancurrah/searchsplunk',


### PR DESCRIPTION
Super trivial, but impacts readability on the PyPI listing...

This switches the long description over to using Markdown formatting instead of assuming reStructuredText/plain text.